### PR TITLE
Update Kinobi and add remaining account signers to addMemo

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-program/memo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "JavaScript client for the Memo program",
   "sideEffects": false,
   "module": "./dist/src/index.js",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-program/memo",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "description": "JavaScript client for the Memo program",
   "sideEffects": false,
   "module": "./dist/src/index.js",

--- a/clients/js/src/generated/instructions/addMemo.ts
+++ b/clients/js/src/generated/instructions/addMemo.ts
@@ -18,11 +18,13 @@ import {
   getStructEncoder,
 } from '@solana/codecs';
 import {
+  AccountRole,
   IAccountMeta,
   IInstruction,
   IInstructionWithAccounts,
   IInstructionWithData,
 } from '@solana/instructions';
+import { TransactionSigner } from '@solana/signers';
 import { MEMO_PROGRAM_ADDRESS } from '../programs';
 
 export type AddMemoInstruction<
@@ -56,6 +58,7 @@ export function getAddMemoInstructionDataCodec(): Codec<
 
 export type AddMemoInput = {
   memo: AddMemoInstructionDataArgs['memo'];
+  signers?: Array<TransactionSigner>;
 };
 
 export function getAddMemoInstruction(
@@ -67,7 +70,17 @@ export function getAddMemoInstruction(
   // Original args.
   const args = { ...input };
 
+  // Remaining accounts.
+  const remainingAccounts: IAccountMeta[] = (args.signers ?? []).map(
+    (signer) => ({
+      address: signer.address,
+      role: AccountRole.READONLY_SIGNER,
+      signer,
+    })
+  );
+
   const instruction = {
+    accounts: remainingAccounts,
     programAddress,
     data: getAddMemoInstructionDataEncoder().encode(
       args as AddMemoInstructionDataArgs

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",
-    "@metaplex-foundation/kinobi": "^0.18.0",
+    "@metaplex-foundation/kinobi": "^0.18.1",
     "@metaplex-foundation/shank-js": "^0.1.7",
     "typescript": "^5.4.2",
     "zx": "^7.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^2.2.5
     version: 2.2.5
   '@metaplex-foundation/kinobi':
-    specifier: ^0.18.0
-    version: 0.18.0(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: ^0.18.1
+    version: 0.18.1(fastestsmallesttextencoderdecoder@1.0.22)
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.7
     version: 0.1.7
@@ -27,8 +27,8 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.18.0(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-iuCUnhCMtm8ixocat5XWAoLFOBOBHhrOS2dulSRUWoLXwtOX8Pnu0wEI0OINN/c/V41Q9kuYXxhlgWh63qg0Zg==}
+  /@metaplex-foundation/kinobi@0.18.1(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-79KntMQa79QGF4orxHu+H8QE7ZDSMk5LiekU4icls1oFqBcex0nqacgytgmtQyCbjj0SlgjeFhdCIRnHV0rE2g==}
     dependencies:
       '@noble/hashes': 1.4.0
       '@prettier/sync': 0.5.1(prettier@3.2.5)

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -8,6 +8,20 @@ const kinobi = k.createFromIdls([
   path.join(workingDirectory, "program", "idl.json"),
 ]);
 
+// Update instructions.
+kinobi.update(
+  k.updateInstructionsVisitor({
+    addMemo: {
+      remainingAccounts: [
+        k.instructionRemainingAccountsNode(k.argumentValueNode("signers"), {
+          isOptional: true,
+          isSigner: true,
+        }),
+      ],
+    },
+  })
+);
+
 // Render JavaScript.
 const jsClient = path.join(__dirname, "..", "clients", "js");
 kinobi.accept(


### PR DESCRIPTION
This PR updates Kinobi to 0.18.1 which now supports remaining account signers.

It also configures the `addMemo` instruction such that a new `signers` array is used as remaining accounts.