### PR TITLE
Fix addMemo string encoding

### DIFF
--- a/clients/js/src/generated/instructions/addMemo.ts
+++ b/clients/js/src/generated/instructions/addMemo.ts
@@ -39,11 +39,11 @@ export type AddMemoInstructionData = { memo: string };
 export type AddMemoInstructionDataArgs = AddMemoInstructionData;
 
 export function getAddMemoInstructionDataEncoder(): Encoder<AddMemoInstructionDataArgs> {
-  return getStructEncoder([['memo', getStringEncoder()]]);
+  return getStructEncoder([['memo', getStringEncoder({ size: 'variable' })]]);
 }
 
 export function getAddMemoInstructionDataDecoder(): Decoder<AddMemoInstructionData> {
-  return getStructDecoder([['memo', getStringDecoder()]]);
+  return getStructDecoder([['memo', getStringDecoder({ size: 'variable' })]]);
 }
 
 export function getAddMemoInstructionDataCodec(): Codec<

--- a/clients/js/test/addMemo.test.ts
+++ b/clients/js/test/addMemo.test.ts
@@ -33,6 +33,8 @@ test('it adds custom text to the transaction logs', async (t) => {
   const instructionDataBase58 =
     result!.transaction.message.instructions[0].data;
   const instructionDataBytes = getBase58Encoder().encode(instructionDataBase58);
-  const instructionMemo = getStringDecoder().decode(instructionDataBytes);
+  const instructionMemo = getStringDecoder({ size: 'variable' }).decode(
+    instructionDataBytes
+  );
   t.is(instructionMemo, 'Hello world!');
 });

--- a/clients/rust/src/generated/instructions/add_memo.rs
+++ b/clients/rust/src/generated/instructions/add_memo.rs
@@ -50,7 +50,7 @@ impl AddMemoInstructionData {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMemoInstructionArgs {
-    pub memo: String,
+    pub memo: &str,
 }
 
 /// Instruction builder for `AddMemo`.
@@ -59,7 +59,7 @@ pub struct AddMemoInstructionArgs {
 ///
 #[derive(Default)]
 pub struct AddMemoBuilder {
-    memo: Option<String>,
+    memo: Option<&str>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
@@ -68,7 +68,7 @@ impl AddMemoBuilder {
         Self::default()
     }
     #[inline(always)]
-    pub fn memo(&mut self, memo: String) -> &mut Self {
+    pub fn memo(&mut self, memo: &str) -> &mut Self {
         self.memo = Some(memo);
         self
     }
@@ -201,7 +201,7 @@ impl<'a, 'b> AddMemoCpiBuilder<'a, 'b> {
         Self { instruction }
     }
     #[inline(always)]
-    pub fn memo(&mut self, memo: String) -> &mut Self {
+    pub fn memo(&mut self, memo: &str) -> &mut Self {
         self.instruction.memo = Some(memo);
         self
     }
@@ -262,7 +262,7 @@ impl<'a, 'b> AddMemoCpiBuilder<'a, 'b> {
 
 struct AddMemoCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
-    memo: Option<String>,
+    memo: Option<&str>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(
         &'b solana_program::account_info::AccountInfo<'a>,

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -12,6 +12,11 @@ const kinobi = k.createFromIdls([
 kinobi.update(
   k.updateInstructionsVisitor({
     addMemo: {
+      arguments: {
+        memo: {
+          type: k.stringTypeNode({ size: k.remainderSizeNode() }),
+        },
+      },
       remainingAccounts: [
         k.instructionRemainingAccountsNode(k.argumentValueNode("signers"), {
           isOptional: true,


### PR DESCRIPTION
The memo program expects the instruction data _not_ to be prefixed by a `u32` number. This PR fixes this.