### PR TITLE
Use Kinobi IDL directly

### DIFF
--- a/program/idl.json
+++ b/program/idl.json
@@ -1,20 +1,44 @@
 {
-  "version": "3.0.1",
-  "name": "memo",
-  "instructions": [
-    {
-      "name": "addMemo",
-      "accounts": [],
-      "args": [
-        {
-          "name": "memo",
-          "type": "string"
-        }
-      ]
-    }
-  ],
-  "metadata": {
-    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "kind": "rootNode",
+  "program": {
+    "kind": "programNode",
+    "pdas": [],
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "memo",
+            "type": { "kind": "stringTypeNode", "encoding": "utf8" },
+            "docs": []
+          }
+        ],
+        "remainingAccounts": [
+          {
+            "kind": "instructionRemainingAccountsNode",
+            "value": { "kind": "argumentValueNode", "name": "signers" },
+            "isOptional": true,
+            "isSigner": true
+          }
+        ],
+        "name": "addMemo",
+        "idlName": "addMemo",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "name": "memo",
+    "prefix": "",
+    "publicKey": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+    "version": "3.0.1",
     "origin": "shank"
-  }
+  },
+  "additionalPrograms": [],
+  "standard": "kinobi",
+  "version": "0.19.0"
 }

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -4,27 +4,8 @@ import * as k from "@metaplex-foundation/kinobi";
 import { workingDirectory } from "./utils.mjs";
 
 // Instanciate Kinobi.
-const kinobi = k.createFromIdl(
-  path.join(workingDirectory, "program", "idl.json")
-);
-
-// Update instructions.
-kinobi.update(
-  k.updateInstructionsVisitor({
-    addMemo: {
-      arguments: {
-        memo: {
-          type: k.stringTypeNode("utf8"),
-        },
-      },
-      remainingAccounts: [
-        k.instructionRemainingAccountsNode(k.argumentValueNode("signers"), {
-          isOptional: true,
-          isSigner: true,
-        }),
-      ],
-    },
-  })
+const kinobi = k.createFromRoot(
+  require(path.join(workingDirectory, "program", "idl.json"))
 );
 
 // Render JavaScript.


### PR DESCRIPTION
This PR uses a Kinobi IDL directly instead of importing and transforming an Anchor/Shank IDL.