### PR TITLE
Use commonjs package type for JS client

### DIFF
--- a/clients/js/.eslintrc.cjs
+++ b/clients/js/.eslintrc.cjs
@@ -1,5 +1,11 @@
 module.exports = {
   extends: ['@solana/eslint-config-solana'],
+  ignorePatterns: ['.eslintrc.cjs', 'tsup.config.ts', 'env-shim.ts'],
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
   rules: {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/sort-type-constituents': 'off',

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@solana-program/memo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "JavaScript client for the Memo program",
   "sideEffects": false,
-  "module": "./dist/src/index.js",
-  "main": "./dist/src/index.cjs",
-  "types": "./dist/types/src/index.d.ts",
-  "type": "module",
+  "module": "./dist/src/index.mjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/types/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/types/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "require": "./dist/src/index.cjs"
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/src/index.mjs",
+      "require": "./dist/src/index.js"
     }
   },
   "files": [

--- a/clients/js/test/addMemo.test.ts
+++ b/clients/js/test/addMemo.test.ts
@@ -5,13 +5,13 @@ import {
   pipe,
 } from '@solana/web3.js';
 import test from 'ava';
-import { getAddMemoInstruction } from '../src/index.js';
+import { getAddMemoInstruction } from '../src';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   generateKeyPairSignerWithSol,
   signAndSendTransaction,
-} from './_setup.js';
+} from './_setup';
 
 test('it adds custom text to the transaction logs', async (t) => {
   // Given a payer wallet.

--- a/clients/js/tsconfig.declarations.json
+++ b/clients/js/tsconfig.declarations.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "emitDeclarationOnly": true,
-      "outDir": "./dist/types",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
   },
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "include": ["src"]
 }

--- a/clients/js/tsup.config.ts
+++ b/clients/js/tsup.config.ts
@@ -7,7 +7,7 @@ const SHARED_OPTIONS: Options = {
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',
-  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.js' }),
+  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.js' : '.mjs' }),
   sourcemap: true,
   treeshake: true,
 };
@@ -22,7 +22,7 @@ export default defineConfig(() => [
     ...SHARED_OPTIONS,
     bundle: false,
     entry: ['./test/*.ts'],
-    format: 'esm',
+    format: 'cjs',
     outDir: './dist/test',
   },
 ]);


### PR DESCRIPTION
After many hours of research, this appears to be the most versatile and interoperable way of publishing dual package libraries.