### PR TITLE
CI: Auto-merge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'solana-program/memo'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

Dependabot can put in a lot of PRs, and it's tedious to need to manually merge each one. Especially when we'll have around 15 program-specific repos.

#### Summary of changes

Since the main branch requires a PR and allows for auto-merge once all the status checks pass, simply enable auto-merge on all dependabot PRs.

Note: this just copies the example at https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request