### PR TITLE
CI: Fix dependabot auto-merge to squash

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'solana-program/memo'
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

The first job with auto-merge failed because it tried to do a merge commit, based on the `--merge` flag.

Here's the job failure: https://github.com/solana-program/memo/actions/runs/11970573036/job/33373602205?pr=49

#### Summary of changes

We typically squash merge and disallow merge commits, so use the `--squash` flag as specified at https://cli.github.com/manual/gh_pr_merge