### PR TITLE
CI: Add audit step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,26 @@ jobs:
       - name: Lint Client Rust
         run: pnpm clients:rust:lint
 
+  audit_rust:
+    name: Audit Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-audit
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo-audit
+        run: pnpm rust:audit
+
   spellcheck_rust:
     name: Spellcheck Rust
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "socket2",
  "thiserror 2.0.3",
  "tokio",
@@ -2947,7 +2947,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "once_cell",
  "ring",
@@ -3321,7 +3321,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -4661,7 +4661,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "solana-connection-cache",
  "solana-measure",
  "solana-metrics",
@@ -5123,7 +5123,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "smallvec",
  "socket2",
  "solana-measure",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "clients:rust:publish": "zx ./scripts/client/publish-rust.mjs",
     "clients:rust:test": "zx ./scripts/client/test-rust.mjs",
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
-    "rust:spellcheck": "cargo spellcheck --code 1"
+    "rust:spellcheck": "cargo spellcheck --code 1",
+    "rust:audit": "zx ./scripts/audit-rust.mjs"
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.1.0",

--- a/scripts/audit-rust.mjs
+++ b/scripts/audit-rust.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+
+const advisories = [
+  // ed25519-dalek: Double Public Key Signing Function Oracle Attack
+  //
+  // Remove once repo upgrades to ed25519-dalek v2
+  'RUSTSEC-2022-0093',
+
+  // curve25519-dalek
+  //
+  // Remove once repo upgrades to curve25519-dalek v4
+  'RUSTSEC-2024-0344',
+
+  // Crate:     tonic
+  // Version:   0.9.2
+  // Title:     Remotely exploitable Denial of Service in Tonic
+  // Date:      2024-10-01
+  // ID:        RUSTSEC-2024-0376
+  // URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
+  // Solution:  Upgrade to >=0.12.3
+  'RUSTSEC-2024-0376',
+];
+const ignores = []
+advisories.forEach(x => {
+  ignores.push('--ignore');
+  ignores.push(x);
+});
+
+// Check Solana version.
+await $`cargo audit ${ignores}`;


### PR DESCRIPTION
#### Problem

The SPL repo runs `cargo audit` on all PRs, but the program-specific repos don't do this yet.

#### Summary of changes

Add a `rust:audit` entry to package.json along with a script for running the audit.

At the same time, there was an open advisory, so I just updated that dependency.