### PR TITLE
scripts: Force `verbose = true`

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,6 +1,7 @@
 import 'zx/globals';
 import { parse as parseToml } from '@iarna/toml';
 
+$.verbose = true;
 process.env.FORCE_COLOR = 3;
 process.env.CARGO_TERM_COLOR = 'always';
 


### PR DESCRIPTION
#### Problem

zx v8 suppresses output from subcommands, as outlined in the migration [guide](https://google.github.io/zx/migration-from-v7#migration-from-v7-to-v8). This makes it challenging to debug issues during CI or local runs.

#### Summary of changes

Set `$.verbose = true` via the utils script so that all jobs become verbose.