### PR TITLE
CI: Add semver-checks step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,26 @@ jobs:
       - name: Run cargo-audit
         run: pnpm rust:audit
 
+  semver_rust:
+    name: Check semver Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-semver
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+
+      - name: Run semver checks
+        run: pnpm rust:semver
+
   spellcheck_rust:
     name: Spellcheck Rust
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5610,7 +5610,7 @@ dependencies = [
 
 [[package]]
 name = "spl-memo-client"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-memo-client"
-version = "0.0.0"
+version = "0.1.0"
 description = "A generated Rust library for the Memo program"
 repository = "https://github.com/solana-program/memo"
 edition = "2021"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clients:rust:test": "zx ./scripts/client/test-rust.mjs",
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
-    "rust:audit": "zx ./scripts/audit-rust.mjs"
+    "rust:audit": "zx ./scripts/audit-rust.mjs",
+    "rust:semver": "cargo semver-checks"
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.1.0",


### PR DESCRIPTION
#### Problem

It's easy to accidentally break semver.

#### Summary of changes

Add a step to CI to run `cargo semver-checks`, which will test for any breakage in any PR. We can always override it if needed and bump the version appropriately.

More info about the tool at https://github.com/obi1kenobi/cargo-semver-checks

NOTE: it's easiest to have another published version to compare against, so I also bumped `spl-memo-client` to 0.1.0 and published it.

For future work, we can also integrate `cargo public-api` https://github.com/cargo-public-api/cargo-public-api