### PR TITLE
Add p-memo program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,6 +2442,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b5f9d6653145815a076efa5d1a7edd214c05d5130cd46a049ededb9f81985f"
+dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
+ "bincode",
+ "mollusk-svm-error",
+ "mollusk-svm-keys",
+ "solana-account",
+ "solana-bpf-loader-program",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-structure",
+ "solana-hash",
+ "solana-instruction",
+ "solana-loader-v3-interface",
+ "solana-log-collector",
+ "solana-logger",
+ "solana-program-error",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-stake-interface",
+ "solana-system-program",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-timings",
+ "solana-transaction-context",
+]
+
+[[package]]
+name = "mollusk-svm-error"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86b4da31faa9d7117817190439362af407e4f26949c4de80456e03f58cfc9a"
+dependencies = [
+ "solana-pubkey",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mollusk-svm-keys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee5fc3f637b3b3d8c2ba3f3df3173ceaaadc83792e84a8cc87dcbb41d435d74"
+dependencies = [
+ "mollusk-svm-error",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-transaction-context",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +2786,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "p-memo"
+version = "0.0.0"
+dependencies = [
+ "mollusk-svm",
+ "pinocchio",
+ "pinocchio-log",
+ "solana-account",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2897,32 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pinocchio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c33b58567c11b07749cefbb8320ac023f3387c57807aeb8e3b1262501b6e9f0"
+
+[[package]]
+name = "pinocchio-log"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89f8ffd986174cefe59448295a004aaf70c3605f30de066f42d27b06188f267"
+dependencies = [
+ "pinocchio-log-macro",
+]
+
+[[package]]
+name = "pinocchio-log-macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edac6ac2c9c456b850d3e908b7f224a54623f6c5b75906b9e48a4e248fb332b"
+dependencies = [
+ "quote",
+ "regex",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["clients/rust", "program"]
+members = ["clients/rust", "p-memo", "program"]
 
 [workspace.metadata.cli]
 solana = "2.2.0"

--- a/p-memo/Cargo.toml
+++ b/p-memo/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "p-memo"
+version = "0.0.0"
+description = "A pinocchio-based Memo program"
+repository = "https://github.com/febo/p-memo"
+license = "Apache-2.0"
+edition = "2021"
+readme = "./README.md"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.solana]
+program-id = "PMemo11111111111111111111111111111111111111"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(target_os, values("solana"))']
+
+[dependencies]
+pinocchio = "0.8"
+pinocchio-log = "0.4"
+
+[dev-dependencies]
+mollusk-svm = "0.1"
+solana-account = "2.2.1"
+solana-instruction = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"

--- a/p-memo/README.md
+++ b/p-memo/README.md
@@ -1,0 +1,54 @@
+# `p-memo`
+
+A `pinocchio`-based Memo program.
+
+## Overview
+
+`p-memo` is a reimplementation of the SPL Memo program using [`pinocchio`](https://github.com/anza-xyz/pinocchio). The program uses at most `~5%` of the compute units used by the current Memo program when signers are present; even when there are no signers, it needs only `~20%` of the current Memo program compute units. This efficiency is achieved by a combination of:
+1. `pinocchio` "lazy" entrypoint
+2. `sol_log_pubkey` syscall to log pubkey values
+3. [`pinocchio-log`](https://crates.io/crates/pinocchio-log) to format the memo message
+
+Since it uses the syscall to log pubkeys, the output of the program is slightly different while loging the same information:
+```
+1: Program PMemo11111111111111111111111111111111111111 invoke [1]
+2: Program log: Signed by:
+3: Program log: 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM
+4: Program log: Memo (len 60): "why does spl memo use 36000 cus to print len 60 msg of ascii"
+5: Program PMemo11111111111111111111111111111111111111 consumed 641 of 1400000 compute units
+6: Program PMemo11111111111111111111111111111111111111 success
+```
+
+Logging begins with entry into the program (`line 1`). Then there is a separate log to start the signers section (`line 2`); this is only present if there are signer accounts. After that there will be one line for each signer account (`line 3`), followed by the memo length and UTF-8 text (`line 4`). The program ends with the status of the instruction (`lines 5-6`).
+
+## Performance
+
+CU comsumption:
+
+| \# signers | p-memo      | SPL Memo  |
+| ---------- | ----------- | --------- |
+| 0          | 406 (`20%`) | 2,022     |
+| 1          | 632 (`5%`)  | 13,525    |
+| 2          | 749 (`3%`)  | 25,111    |
+| 3          | 866 (`2%`)  | 36,406    |
+
+> [!NOTE]
+> Using Solana CLI `v2.2.15`.
+
+## Building
+
+To build the program from its directory:
+```bash
+cargo build-sbf
+```
+
+## Testing
+
+To run the tests (after building the program):
+```bash
+SBF_OUT_DIR=../target/deploy cargo test
+```
+
+## License
+
+The code is licensed under the [Apache License Version 2.0](LICENSE)

--- a/p-memo/README.md
+++ b/p-memo/README.md
@@ -14,12 +14,13 @@ Since it uses the syscall to log pubkeys, the output of the program is slightly 
 1: Program PMemo11111111111111111111111111111111111111 invoke [1]
 2: Program log: Signed by:
 3: Program log: 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM
-4: Program log: Memo (len 60): "why does spl memo use 36000 cus to print len 60 msg of ascii"
-5: Program PMemo11111111111111111111111111111111111111 consumed 641 of 1400000 compute units
-6: Program PMemo11111111111111111111111111111111111111 success
+4: Program log: Memo (len 60):
+5: Program log: why does spl memo use 36000 cus to print len 60 msg of ascii
+6: Program PMemo11111111111111111111111111111111111111 consumed 537 of 1400000 compute units
+7: Program PMemo11111111111111111111111111111111111111 success
 ```
 
-Logging begins with entry into the program (`line 1`). Then there is a separate log to start the signers section (`line 2`); this is only present if there are signer accounts. After that there will be one line for each signer account (`line 3`), followed by the memo length and UTF-8 text (`line 4`). The program ends with the status of the instruction (`lines 5-6`).
+Logging begins with entry into the program (`line 1`). Then there is a separate log to start the signers section (`line 2`); this is only present if there are signer accounts. After that there will be one line for each signer account (`line 3`), followed by the memo length and UTF-8 text (`line 4-5`). The program ends with the status of the instruction (`lines 6-7`).
 
 ## Performance
 
@@ -27,10 +28,10 @@ CU comsumption:
 
 | \# signers | p-memo      | SPL Memo  |
 | ---------- | ----------- | --------- |
-| 0          | 406 (`20%`) | 2,022     |
-| 1          | 632 (`5%`)  | 13,525    |
-| 2          | 749 (`3%`)  | 25,111    |
-| 3          | 866 (`2%`)  | 36,406    |
+| 0          | 313 (`15%`) | 2,022     |
+| 1          | 537 (`4%`)  | 13,525    |
+| 2          | 654 (`3%`)  | 25,111    |
+| 3          | 771 (`2%`)  | 36,406    |
 
 > [!NOTE]
 > Using Solana CLI `v2.2.15`.

--- a/p-memo/src/entrypoint.rs
+++ b/p-memo/src/entrypoint.rs
@@ -1,8 +1,7 @@
-use core::str::from_utf8;
 use pinocchio::{
     entrypoint::{InstructionContext, MaybeAccount},
     program_error::ProgramError,
-    syscalls::sol_log_pubkey,
+    syscalls::{sol_log_, sol_log_pubkey},
     ProgramResult,
 };
 use pinocchio_log::log;
@@ -17,6 +16,7 @@ pub fn process_instruction(mut context: InstructionContext) -> ProgramResult {
     let mut missing_required_signature = false;
 
     // Validates signer accounts (if any).
+
     if context.remaining() > 0 {
         // Logs a message indicating that there are signers.
         log!("Signed by:");
@@ -43,15 +43,12 @@ pub fn process_instruction(mut context: InstructionContext) -> ProgramResult {
     let instruction_data = unsafe { context.instruction_data_unchecked() };
 
     // Logs the length of the memo message and its content.
-    log!(
-        1300,
-        "Memo (len {}): \"{}\"",
-        instruction_data.len(),
-        from_utf8(instruction_data).map_err(|error| {
-            log!(1300, "Invalid UTF-8, from byte {}", error.valid_up_to());
-            ProgramError::InvalidInstructionData
-        })?
-    );
+
+    log!("Memo (len {}):", instruction_data.len());
+    // SAFETY: The syscall will validate the UTF-8 encoding of the memo data.
+    unsafe {
+        sol_log_(instruction_data.as_ptr(), instruction_data.len() as u64);
+    }
 
     Ok(())
 }

--- a/p-memo/src/entrypoint.rs
+++ b/p-memo/src/entrypoint.rs
@@ -1,0 +1,57 @@
+use core::str::from_utf8;
+use pinocchio::{
+    entrypoint::{InstructionContext, MaybeAccount},
+    program_error::ProgramError,
+    syscalls::sol_log_pubkey,
+    ProgramResult,
+};
+use pinocchio_log::log;
+
+/// Process a memo instruction.
+///
+/// This function processes a memo instruction by logging the public keys of the signers
+/// (if any) and the memo data itself, checking if the required signatures are present;
+/// when any required signature is missing, it returns `ProgramError::MissingRequiredSignature`
+/// error.
+pub fn process_instruction(mut context: InstructionContext) -> ProgramResult {
+    let mut missing_required_signature = false;
+
+    // Validates signer accounts (if any).
+    if context.remaining() > 0 {
+        // Logs a message indicating that there are signers.
+        log!("Signed by:");
+
+        while context.remaining() > 0 {
+            // Duplicated accounts are implicitly checked since at least one of the
+            // "copies" must be a signer.
+            if let MaybeAccount::Account(account) = context.next_account()? {
+                if account.is_signer() {
+                    // SAFETY: Use the syscall to log the public key of the account.
+                    unsafe { sol_log_pubkey(account.key().as_ptr()) };
+                } else {
+                    missing_required_signature = true;
+                }
+            }
+        }
+
+        if missing_required_signature {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+    }
+
+    // SAFETY: All accounts have been processed.
+    let instruction_data = unsafe { context.instruction_data_unchecked() };
+
+    // Logs the length of the memo message and its content.
+    log!(
+        1300,
+        "Memo (len {}): \"{}\"",
+        instruction_data.len(),
+        from_utf8(instruction_data).map_err(|error| {
+            log!(1300, "Invalid UTF-8, from byte {}", error.valid_up_to());
+            ProgramError::InvalidInstructionData
+        })?
+    );
+
+    Ok(())
+}

--- a/p-memo/src/lib.rs
+++ b/p-memo/src/lib.rs
@@ -1,0 +1,23 @@
+//! A pinocchio-based Memo (aka 'p-memo') program.
+//!
+//! The Memo program is a simple program that validates a string of UTF-8 encoded
+//! characters and verifies that any accounts provided are signers of the transaction.
+//! The program also logs the memo, as well as any verified signer addresses, to the
+//! transaction log, so that anyone can easily observe memos and know they were
+//! approved by zero or more addresses by inspecting the transaction log from a
+//! trusted provider.
+
+#![no_std]
+
+mod entrypoint;
+
+use pinocchio::{lazy_program_entrypoint, no_allocator, nostd_panic_handler};
+
+use crate::entrypoint::process_instruction;
+
+// Process the input lazily.
+lazy_program_entrypoint!(process_instruction);
+// Disable the memory allocator.
+no_allocator!();
+// Use a `no_std` panic handler.
+nostd_panic_handler!();

--- a/p-memo/tests/memo.rs
+++ b/p-memo/tests/memo.rs
@@ -1,0 +1,122 @@
+use mollusk_svm::{result::Check, Mollusk};
+use solana_account::Account;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+
+/// Program ID for the p-memo program.
+const PROGRAM_ID: Pubkey = Pubkey::from_str_const("PMemo11111111111111111111111111111111111111");
+
+/// The memo to be printed.
+const MEMO: &str = "why does spl memo use 36000 cus to print len 60 msg of ascii";
+
+/// Creates an instruction for the p-memo program.
+fn instruction(message: &[u8], signers: Option<&[Pubkey]>) -> Instruction {
+    let accounts = if let Some(signers) = signers {
+        let mut accounts = Vec::with_capacity(signers.len());
+        for signer in signers {
+            accounts.push(AccountMeta::new_readonly(*signer, true));
+        }
+        accounts
+    } else {
+        Vec::new()
+    };
+
+    Instruction {
+        program_id: PROGRAM_ID,
+        accounts,
+        data: message.to_vec(),
+    }
+}
+
+#[test]
+fn test_valid_ascii_no_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let instruction = instruction(MEMO.as_bytes(), None);
+
+    mollusk.process_and_validate_instruction(&instruction, &[], &[Check::success()]);
+}
+
+#[test]
+fn fail_test_invalid_ascii_no_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let instruction = instruction(&[255, 255], None);
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[],
+        &[Check::err(ProgramError::InvalidInstructionData)],
+    );
+}
+
+#[test]
+fn test_valid_ascii_one_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let signer = Pubkey::new_unique();
+    let instruction = instruction(MEMO.as_bytes(), Some(&[signer]));
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[(signer, Account::default())],
+        &[Check::success()],
+    );
+}
+
+#[test]
+fn test_valid_ascii_two_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let signers = [Pubkey::new_unique(), Pubkey::new_unique()];
+    let instruction = instruction(MEMO.as_bytes(), Some(&signers));
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &signers
+            .iter()
+            .map(|signer| (*signer, Account::default()))
+            .collect::<Vec<(Pubkey, Account)>>(),
+        &[Check::success()],
+    );
+}
+
+#[test]
+fn test_valid_ascii_three_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let signers = [
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    ];
+    let instruction = instruction(MEMO.as_bytes(), Some(&signers));
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &signers
+            .iter()
+            .map(|signer| (*signer, Account::default()))
+            .collect::<Vec<(Pubkey, Account)>>(),
+        &[Check::success()],
+    );
+}
+
+#[test]
+fn test_valid_ascii_duplicated_accounts() {
+    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+
+    let unique = Pubkey::new_unique();
+    let duplicated = Pubkey::new_unique();
+    let instruction = instruction(MEMO.as_bytes(), Some(&[duplicated, unique, duplicated]));
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[
+            (duplicated, Account::default()),
+            (unique, Account::default()),
+        ],
+        &[Check::success()],
+    );
+}


### PR DESCRIPTION
### Problem

Current Memo program implementation uses more CUs than it needs.

### Solution

Re-implement the Memo program using `pinocchio` to improve its CU consumption.

Note that the output of the re-implementation is slightly different since it uses the log syscall to format and log pubkeys, which avoid having to do the base58 conversion on-chain.

#### Sample output

Program output with one signer: 
```
Program PMemo11111111111111111111111111111111111111 invoke [1]
Program log: Signed by:
Program log: 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM
Program log: Memo (len 60):
Program log: why does spl memo use 13525 cus to print len 60 msg of ascii
Program PMemo11111111111111111111111111111111111111 consumed 537 of 1400000 compute units
Program PMemo11111111111111111111111111111111111111 success
```

#### CU comsumption

| \# signers | p-memo      | SPL Memo  |
| ---------- | ----------- | --------- |
| 0          | 313 (`15%`) | 2,022     |
| 1          | 537 (`4%`)  | 13,525    |
| 2          | 654 (`3%`)  | 25,111    |
| 3          | 771 (`2%`)  | 36,406    |

**Note:** CI integration will be done in a follow-up PR.

cc: @rustopian