### PR TITLE
Enable serde feature for kaigan dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba15de5aeb137f0f65aa3bf82187647f1285abfe5b20c80c2c37f7007ad519a"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
 ]
 
 [[package]]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -9,7 +9,7 @@ license-file = "../../LICENSE"
 
 [features]
 test-sbf = []
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
 borsh = "^0.10"


### PR DESCRIPTION
### Problem

The rust client crate supports `serde` derivation but does not enable the feature on kaigan types.

### Solution

Enable the `serde` feature on kaigan when the feature in enabled.