### PR TITLE
makefile: Add --all-features to clippy job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ spellcheck:
 clippy-%:
 	cargo $(nightly) clippy --manifest-path $(call make-path,$*)/Cargo.toml \
 	  --all-targets \
+	  --all-features \
 		-- \
 		--deny=warnings \
 		--deny=clippy::default_trait_access \


### PR DESCRIPTION
#### Problem

The clippy job doesn't enable all features, which means we could miss some warnings.

#### Summary of changes

Add `--all-features` to the clippy target.