### PR TITLE
p-memo: Update dependencies and program address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,8 +1702,7 @@ checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
- "solana-instruction-view",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
 ]
 
@@ -2240,7 +2239,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -2300,7 +2299,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -2398,9 +2397,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-epoch-rewards"
@@ -2481,7 +2480,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
 ]
@@ -2495,18 +2494,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-program-error",
-]
-
-[[package]]
-name = "solana-instruction-view"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
-dependencies = [
- "solana-account-view",
- "solana-address 2.6.0",
- "solana-define-syscall 5.0.0",
  "solana-program-error",
 ]
 
@@ -2615,7 +2602,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]
@@ -2696,19 +2683,19 @@ checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 
 [[package]]
 name = "solana-program-log"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26115ff9ec592bb4407379c82e7f00b9d0ae4e3fac80c3fd28c932aec852dc6"
+checksum = "ffd48ddef444e6db138fb11bdb9ab8117bb830a78cef051a453454de5613039b"
 dependencies = [
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-program-log-macro",
 ]
 
 [[package]]
 name = "solana-program-log-macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2b224806ef141865d2f4b4614179089e3b80ba7311fc3bb28742c1d8323946"
+checksum = "73b234f83b71ba6b5d3236b69ba42ccb639907cb724bf58e94ce8398b51ac87c"
 dependencies = [
  "quote",
  "regex",
@@ -2851,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
 dependencies = [
  "k256",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -15,3 +15,8 @@ pub mod v1 {
 pub mod v3 {
     solana_pubkey::declare_id!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
 }
+
+/// Symbols from Memo version 4
+pub mod v4 {
+    solana_pubkey::declare_id!("Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH");
+}

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -12,15 +12,15 @@ publish = false
 crate-type = ["cdylib"]
 
 [package.metadata.solana]
-program-id = "PMemo11111111111111111111111111111111111111"
+program-id = "Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(target_os, values("solana"))']
 
 [dependencies]
-pinocchio = "0.11"
-solana-program-log = "1.1"
+pinocchio = { version = "0.11", default-features = false }
+solana-program-log = "1.2"
 
 [dev-dependencies]
 mollusk-svm = "0.12"

--- a/pinocchio/README.md
+++ b/pinocchio/README.md
@@ -4,20 +4,20 @@ A `pinocchio`-based Memo program.
 
 ## Overview
 
-`p-memo` is a reimplementation of the SPL Memo program using [`pinocchio`](https://github.com/anza-xyz/pinocchio). The program uses at most `~4%` of the compute units used by the current Memo program when signers are present; even when there are no signers, it needs only `~15%` of the current Memo program compute units. This efficiency is achieved by a combination of:
+`p-memo` is a reimplementation of the SPL Memo program using [`pinocchio`](https://github.com/anza-xyz/pinocchio). The program uses at most `~4%` of the compute units used by the current Memo program when signers are present; even when there are no signers, it needs only `~14%` of the current Memo program compute units. This efficiency is achieved by a combination of:
 1. `pinocchio` "lazy" entrypoint
 2. `sol_log_pubkey` syscall to log pubkey values
 3. [`solana-program-log`](https://crates.io/crates/solana-program-log) to format the memo message
 
 Since it uses the syscall to log pubkeys, the output of the program is slightly different while loging the same information:
 ```
-1: Program PMemo11111111111111111111111111111111111111 invoke [1]
+1: Program Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH invoke [1]
 2: Program log: Signed by:
 3: Program log: 1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM
 4: Program log: Memo (len 60):
 5: Program log: why does spl memo use 36000 cus to print len 60 msg of ascii
-6: Program PMemo11111111111111111111111111111111111111 consumed 537 of 1400000 compute units
-7: Program PMemo11111111111111111111111111111111111111 success
+6: Program Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH consumed 537 of 1400000 compute units
+7: Program Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH success
 ```
 
 Logging begins with entry into the program (`line 1`). Then there is a separate log to start the signers section (`line 2`); this is only present if there are signer accounts. After that there will be one line for each signer account (`line 3`), followed by the memo length and UTF-8 text (`line 4-5`). The program ends with the status of the instruction (`lines 6-7`).
@@ -28,10 +28,10 @@ CU comsumption:
 
 | \# signers | p-memo      | SPL Memo  |
 | ---------- | ----------- | --------- |
-| 0          | 313 (`15%`) | 2,022     |
-| 1          | 537 (`4%`)  | 13,525    |
-| 2          | 654 (`3%`)  | 25,111    |
-| 3          | 771 (`2%`)  | 36,406    |
+| 0          | 287 (`14%`) | 2,022     |
+| 1          | 513 (`4%`)  | 13,525    |
+| 2          | 628 (`3%`)  | 25,111    |
+| 3          | 743 (`2%`)  | 36,406    |
 
 > [!NOTE]
 > Using Solana CLI `v2.2.15`.

--- a/pinocchio/src/entrypoint.rs
+++ b/pinocchio/src/entrypoint.rs
@@ -1,9 +1,11 @@
-use pinocchio::{
-    entrypoint::{InstructionContext, MaybeAccount},
-    error::ProgramError,
-    ProgramResult,
+use {
+    pinocchio::{
+        entrypoint::{InstructionContext, MaybeAccount},
+        error::ProgramError,
+        ProgramResult,
+    },
+    solana_program_log::log,
 };
-use solana_program_log::log;
 
 /// Process a memo instruction.
 ///

--- a/pinocchio/src/lib.rs
+++ b/pinocchio/src/lib.rs
@@ -9,11 +9,12 @@
 
 #![no_std]
 
+use {
+    crate::entrypoint::process_instruction,
+    pinocchio::{lazy_program_entrypoint, no_allocator, nostd_panic_handler},
+};
+
 mod entrypoint;
-
-use pinocchio::{lazy_program_entrypoint, no_allocator, nostd_panic_handler};
-
-use crate::entrypoint::process_instruction;
 
 // Process the input lazily.
 lazy_program_entrypoint!(process_instruction);

--- a/pinocchio/tests/memo.rs
+++ b/pinocchio/tests/memo.rs
@@ -5,7 +5,7 @@ use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 
 /// Program ID for the p-memo program.
-const PROGRAM_ID: Pubkey = Pubkey::from_str_const("PMemo11111111111111111111111111111111111111");
+const PROGRAM_ID: Pubkey = Pubkey::from_str_const("Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH");
 
 /// The memo to be printed.
 const MEMO: &str = "why does spl memo use 36000 cus to print len 60 msg of ascii";


### PR DESCRIPTION
### Problem

Currently p-memo is using a "test" program address and an older version of solana-program-log.

### Solution

Update the dependencies and program address.