### PR TITLE
chore: fix package.authors and package.repository

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -2,8 +2,8 @@
 name = "spl-memo-interface"
 version = "2.1.0"
 description = "Solana Program Library Memo Interface"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/memo"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -2,6 +2,7 @@
 name = "p-memo"
 version = "0.0.0"
 description = "A pinocchio-based Memo program"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/memo"
 license = "Apache-2.0"
 edition = "2021"

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "p-memo"
 version = "0.0.0"
 description = "A pinocchio-based Memo program"
-repository = "https://github.com/febo/p-memo"
+repository = "https://github.com/solana-program/memo"
 license = "Apache-2.0"
 edition = "2021"
 readme = "./README.md"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -2,8 +2,8 @@
 name = "spl-memo"
 version = "6.0.0"
 description = "Solana Program Library Memo"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/memo"
 license = "Apache-2.0"
 edition = "2021"
 


### PR DESCRIPTION
#### Problem

it's a bit confused that https://crates.io/crates/spl-memo-interface/2.1.0 is still showing

<img width="301" height="89" alt="Screenshot 2026-05-22 at 23 14 57" src="https://github.com/user-attachments/assets/4c121fdb-33d6-4fd7-a517-75706619f1bd" />

#### Summary of Changes

- update authors to `Anza Maintainers <maintainers@anza.xyz>`
- update repository to `https://github.com/solana-program/memo`
