### PR TITLE
p-memo: Update version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,19 +1638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "p-memo"
-version = "0.0.0"
-dependencies = [
- "mollusk-svm",
- "pinocchio",
- "solana-account",
- "solana-instruction",
- "solana-program-error",
- "solana-program-log",
- "solana-pubkey 4.2.0",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1691,19 @@ dependencies = [
  "solana-address 2.6.0",
  "solana-define-syscall 5.1.0",
  "solana-program-error",
+]
+
+[[package]]
+name = "pinocchio-memo-program"
+version = "1.0.0"
+dependencies = [
+ "mollusk-svm",
+ "pinocchio",
+ "solana-account",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-log",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-memo-program"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "mollusk-svm",
  "pinocchio",

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinocchio-memo-program"
-version = "1.0.0"
+version = "0.0.0"
 description = "A pinocchio-based Memo program"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/memo"

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "p-memo"
-version = "0.0.0"
+name = "pinocchio-memo-program"
+version = "1.0.0"
 description = "A pinocchio-based Memo program"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/memo"

--- a/pinocchio/Cargo.toml
+++ b/pinocchio/Cargo.toml
@@ -7,7 +7,6 @@ repository = "https://github.com/solana-program/memo"
 license = "Apache-2.0"
 edition = "2021"
 readme = "./README.md"
-publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
### Problem

<del>p-memo was deployed to mainnet, but its version number is still set to `0.0.0`.</del>

p-memo was deployed to mainnet, but its crate is not published yet.

### Solution

<del>Update the version and name on `Cargo.toml`. After this, a tag and verifiable build details will be created.</del>

Update the publish and name on `Cargo.toml`. After this, the crate will be published and verifiable build details will be created.