### PR TITLE
p-memo: Update binary name

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -67,7 +67,7 @@ jobs:
     needs: set_env
     uses: solana-program/actions/.github/workflows/publish-rust.yml@main
     with:
-      sbpf-program-packages: "program"
+      sbpf-program-packages: "program pinocchio"
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
       clippy-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       rustfmt-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}

--- a/pinocchio/tests/memo.rs
+++ b/pinocchio/tests/memo.rs
@@ -31,7 +31,7 @@ fn instruction(message: &[u8], signers: Option<&[Pubkey]>) -> Instruction {
 
 #[test]
 fn test_valid_ascii_no_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let instruction = instruction(MEMO.as_bytes(), None);
 
@@ -40,7 +40,7 @@ fn test_valid_ascii_no_accounts() {
 
 #[test]
 fn fail_test_invalid_ascii_no_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let instruction = instruction(&[255, 255], None);
 
@@ -55,7 +55,7 @@ fn fail_test_invalid_ascii_no_accounts() {
 
 #[test]
 fn test_valid_ascii_one_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let signer = Pubkey::new_unique();
     let instruction = instruction(MEMO.as_bytes(), Some(&[signer]));
@@ -69,7 +69,7 @@ fn test_valid_ascii_one_accounts() {
 
 #[test]
 fn fail_test_invalid_missing_signer() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let signer = Pubkey::new_unique();
     let mut instruction = instruction(MEMO.as_bytes(), Some(&[signer]));
@@ -85,7 +85,7 @@ fn fail_test_invalid_missing_signer() {
 
 #[test]
 fn test_valid_ascii_two_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let signers = [Pubkey::new_unique(), Pubkey::new_unique()];
     let instruction = instruction(MEMO.as_bytes(), Some(&signers));
@@ -102,7 +102,7 @@ fn test_valid_ascii_two_accounts() {
 
 #[test]
 fn test_valid_ascii_three_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let signers = [
         Pubkey::new_unique(),
@@ -123,7 +123,7 @@ fn test_valid_ascii_three_accounts() {
 
 #[test]
 fn test_valid_ascii_duplicated_accounts() {
-    let mollusk = Mollusk::new(&PROGRAM_ID, "p_memo");
+    let mollusk = Mollusk::new(&PROGRAM_ID, "pinocchio_memo_program");
 
     let unique = Pubkey::new_unique();
     let duplicated = Pubkey::new_unique();


### PR DESCRIPTION
### Problem

PR #374 update the binary name for p-memo, but missed the name used in the tests so they are [failing](https://github.com/solana-program/memo/actions/runs/26479246728) now.

Update: the failure was due to the missing "pinocchio" package name, but it would have failed for having the wrong binary name as well.

### Solution

Update the name of the binary in the program test files.