### PR TITLE
Migrate JS tests from local validator to LiteSVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ format-check-js-%:
 lint-js-%:
 	cd $(call make-path,$*) && pnpm install && pnpm lint $(ARGS)
 
+# LiteSVM-flavoured: no validator needed for the Kit-based JS client.
+test-js-clients-js:
+	cd clients/js && pnpm install && pnpm build && pnpm test $(ARGS)
+
+# Validator-flavoured: still needed for clients-js-legacy (jest e2e tests
+# against a live local validator at http://127.0.0.1:8899).
 test-js-%:
 	make restart-test-validator
 	cd $(call make-path,$*) && pnpm install && pnpm build && pnpm test $(ARGS)

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -4,24 +4,19 @@ A generated JavaScript library for the Memo program.
 
 ## Getting started
 
-To build and test your JavaScript client from the root of the repository, you may use the following command.
+The JS client tests use [LiteSVM](https://github.com/LiteSVM/litesvm) in-process, so no local validator is needed. From the root of the repository:
 
 ```sh
-pnpm clients:js:test
+make test-js-clients-js
 ```
 
-This will start a new local validator, if one is not already running, and run the tests for your JavaScript client.
+This installs dependencies, builds the client, and runs the test suite. The memo program is loaded into LiteSVM from the `.so` artifact that CI's `build-sbf-program` job (or your local `make build-sbf-program`) emits to `target/deploy/spl_memo.so`.
 
-## Available client scripts.
+## Available client scripts
 
-Alternatively, you can go into the client directory and run the tests directly.
+Alternatively, you can go into the client directory and run the scripts directly.
 
 ```sh
-# Build your programs and start the validator.
-pnpm programs:build
-pnpm validator:restart
-
-# Go into the client directory and run the tests.
 cd clients/js
 pnpm install
 pnpm build
@@ -36,3 +31,5 @@ pnpm lint:fix
 pnpm format
 pnpm format:fix
 ```
+
+Equivalent `make` targets from the repo root are `make lint-js-clients-js` and `make format-check-js-clients-js`.

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -49,7 +49,7 @@
     "devDependencies": {
         "@solana/eslint-config-solana": "^3.0.3",
         "@solana/kit": "^6.9.0",
-        "@solana/kit-plugin-rpc": "^0.11.1",
+        "@solana/kit-plugin-litesvm": "^0.10.0",
         "@solana/kit-plugin-signer": "^0.10.0",
         "@types/node": "^24",
         "@typescript-eslint/eslint-plugin": "^7.16.1",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@solana/kit':
         specifier: ^6.9.0
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/kit-plugin-rpc':
-        specifier: ^0.11.1
-        version: 0.11.1(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit-plugin-litesvm':
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit-plugin-signer':
         specifier: ^0.10.0
         version: 0.10.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
@@ -520,6 +520,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@solana-program/system@0.12.1':
+    resolution: {integrity: sha512-atn3PTTu6bG1cOvDY50JPaysWFdpPu03U/tanS0ikpINqnBZL5wEQvep8mx4Qkt18XUUp8DXvPjnzmVULUWCwQ==}
+    peerDependencies:
+      '@solana/kit': ^6.4.0
+
+  '@solana-program/token@0.13.0':
+    resolution: {integrity: sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==}
+    peerDependencies:
+      '@solana/kit': ^6.5.0
+
   '@solana/accounts@6.9.0':
     resolution: {integrity: sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==}
     engines: {node: '>=20.18.0'}
@@ -677,8 +687,8 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.8.0
 
-  '@solana/kit-plugin-rpc@0.11.1':
-    resolution: {integrity: sha512-NpCKBY6y3lmOOZjzm5dvk/+iZsKOH+Wc9TQx5yKZ0RzNOXC6V9i0Inn+niVdkX5ECDJOmClfa64bLcImFJWLuQ==}
+  '@solana/kit-plugin-litesvm@0.10.0':
+    resolution: {integrity: sha512-ks/sbFyYJOpa4BrdzEpp2karA66N4b1DFnWol3bui/UzJm+YJZ65xnOyeX9U8PC8uF/TPVkgf6oYvsxyLqrxIw==}
     peerDependencies:
       '@solana/kit': ^6.8.0
 
@@ -1597,6 +1607,46 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  litesvm-darwin-arm64@1.1.0:
+    resolution: {integrity: sha512-SjcivEOOjBk65U6TgIeMJ7CCnHNKQXHx0qf6K6GIFZC1aHTg7ePrEi+WhAQD6VUBMdDHIMCVKC/uXnXPi6EKIw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  litesvm-darwin-x64@1.1.0:
+    resolution: {integrity: sha512-hTs+eZ9sHVZXhjggpnn/8A/E+Nt/E6Gf8E2ejdWWL9bBQKmq1Y0VcrDpORbIvqqRpTLHXqbxCuH1wQB2C8frJg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  litesvm-linux-arm64-gnu@1.1.0:
+    resolution: {integrity: sha512-6EjJ6+E+1SUXdJmCyeyhvlKhNncccqQNH241+P8d4E72rE3zuFxeCtLHhusCQk2p/Xau3dBI0qTLogZ1F1IGSA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  litesvm-linux-arm64-musl@1.1.0:
+    resolution: {integrity: sha512-mNuBOfX6GnDFT2i/kYPWud7eZGe57dDP0u4lwiSTQPRE0BxQbGZT2aEwX8LTwbonhbc6HSt50LamaZZzK4h4ig==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  litesvm-linux-x64-gnu@1.1.0:
+    resolution: {integrity: sha512-Ot8RgUVlMKzKJi2nVDxaHVo0hjB5vtYTomYNIf26mIA32DOy0+dQfwOqUhynhvvSMxN3VFec3r/OtCnk6lRBrw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  litesvm-linux-x64-musl@1.1.0:
+    resolution: {integrity: sha512-6kmneOIsTBSActELRTwxIYVJOVaLm3P6uwlmkqc9BUtDAQ7bRdRmwREWSbM8XxKBGw2LjiUfgRJ5WJGYo8fUFg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  litesvm@1.1.0:
+    resolution: {integrity: sha512-UOlMIEst50gSUyPnC2pGjGLygH8iC/GOqnNXQIHc8iGwD76m44ReeA/0h0vu/AIieZ2zG5/ERLxFV0kdNxkNsA==}
+    engines: {node: '>= 20'}
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2443,6 +2493,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@solana-program/system@0.12.1(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
+  '@solana-program/token@0.13.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.12.1(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
   '@solana/accounts@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2588,10 +2647,16 @@ snapshots:
     dependencies:
       '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
-  '@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana/kit-plugin-litesvm@0.10.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      litesvm: 1.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@solana/kit-plugin-signer@0.10.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
@@ -3627,6 +3692,42 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  litesvm-darwin-arm64@1.1.0:
+    optional: true
+
+  litesvm-darwin-x64@1.1.0:
+    optional: true
+
+  litesvm-linux-arm64-gnu@1.1.0:
+    optional: true
+
+  litesvm-linux-arm64-musl@1.1.0:
+    optional: true
+
+  litesvm-linux-x64-gnu@1.1.0:
+    optional: true
+
+  litesvm-linux-x64-musl@1.1.0:
+    optional: true
+
+  litesvm@1.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3):
+    dependencies:
+      '@solana-program/system': 0.12.1(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana-program/token': 0.13.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      litesvm-darwin-arm64: 1.1.0
+      litesvm-darwin-x64: 1.1.0
+      litesvm-linux-arm64-gnu: 1.1.0
+      litesvm-linux-arm64-musl: 1.1.0
+      litesvm-linux-x64-gnu: 1.1.0
+      litesvm-linux-x64-musl: 1.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   load-tsconfig@0.2.5: {}
 

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -1,13 +1,24 @@
+import path from 'node:path';
+
 import { createClient, lamports } from '@solana/kit';
-import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { litesvm } from '@solana/kit-plugin-litesvm';
 import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 
-import { memoProgram } from '../src';
+import { MEMO_PROGRAM_ADDRESS, memoProgram } from '../src';
+
+const MEMO_BINARY_PATH = path.resolve(__dirname, '..', '..', '..', 'target', 'deploy', 'spl_memo.so');
 
 export const createTestClient = () => {
     return createClient()
         .use(generatedSigner())
-        .use(solanaLocalRpc())
+        .use(litesvm())
         .use(airdropSigner(lamports(1_000_000_000n)))
+        .use(client => {
+            // Load the memo program into the LiteSVM instance from its compiled
+            // `.so` file. Must run after the `litesvm()` plugin so that
+            // `client.svm` is available.
+            client.svm.addProgramFromFile(MEMO_PROGRAM_ADDRESS, MEMO_BINARY_PATH);
+            return client;
+        })
         .use(memoProgram());
 };

--- a/clients/js/test/addMemo.test.ts
+++ b/clients/js/test/addMemo.test.ts
@@ -1,4 +1,4 @@
-import { getBase58Encoder, getUtf8Decoder } from '@solana/kit';
+import { getUtf8Decoder } from '@solana/kit';
 import { expect, it } from 'vitest';
 
 import { MEMO_PROGRAM_ADDRESS } from '../src';
@@ -10,20 +10,17 @@ it('adds custom text to the transaction logs', async () => {
 
     // When the payer sends a transaction with a custom memo.
     const {
-        context: { signature },
+        context: { message, signature },
     } = await client.memo.instructions.addMemo({ memo: 'Hello world!' }).sendTransaction();
 
-    // Then the instruction data of the memo instruction contains our memo text.
-    const result = await client.rpc
-        .getTransaction(signature, {
-            encoding: 'json',
-            maxSupportedTransactionVersion: 0,
-        })
-        .send();
-    const { accountKeys, instructions } = result!.transaction.message;
-    const memoInstruction = instructions.find(ix => accountKeys[ix.programIdIndex] === MEMO_PROGRAM_ADDRESS);
+    // Then the planned message contains a memo instruction carrying our memo text.
+    const memoInstruction = message?.instructions.find(ix => ix.programAddress === MEMO_PROGRAM_ADDRESS);
     expect(memoInstruction).toBeTruthy();
-    const instructionDataBytes = getBase58Encoder().encode(memoInstruction!.data);
-    const instructionMemo = getUtf8Decoder().decode(instructionDataBytes);
-    expect(instructionMemo).toBe('Hello world!');
+    expect(memoInstruction?.data).toBeDefined();
+    expect(getUtf8Decoder().decode(memoInstruction!.data!)).toBe('Hello world!');
+
+    // And the on-chain transaction logs include the memo text.
+    const tx = client.svm.getTransaction(signature) as { logs: () => string[] } | null;
+    expect(tx).not.toBeNull();
+    expect(tx!.logs()).toEqual(expect.arrayContaining([expect.stringContaining('Memo (len 12): "Hello world!"')]));
 });


### PR DESCRIPTION
This PR swaps the JS client's test runtime from a live `solana-test-validator` to LiteSVM running in-process, matching the converged pattern used by `system` and `program-metadata`. The single `addMemo` test now loads `spl_memo.so` via `client.svm.addProgramFromFile(...)` and verifies the memo end-to-end against both the planned-and-signed message and the on-chain transaction logs. The `clients-js-legacy` client stays on the local-validator flow, so a new explicit `test-js-clients-js:` Makefile target carries the LiteSVM recipe while the existing `test-js-%:` pattern continues to handle the legacy client.