### PR TITLE
program: Add deprecate note

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,8 +1,20 @@
+#![deprecated(
+    since = "6.1.0",
+    note = "Please use `spl-memo-interface` for instruction types, and `pinocchio-memo-program` for the program implementation"
+)]
 #![deny(missing_docs)]
 
 //! A program that accepts a string of encoded characters and verifies that it
 //! parses, while verifying and logging signers. Currently handles UTF-8
 //! characters.
+//!
+//! `⚠️ DEPRECATED`
+//!
+//! This crate has been deprecated and is no longer actively maintained.
+//!
+//! Please use [spl-memo-interface](https://crates.io/crates/spl-memo-interface) for
+//! instruction types, and [pinocchio-memo-program](https://crates.io/crates/pinocchio-memo-program)
+//! for the program implementation.
 
 mod entrypoint;
 pub mod processor;

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use {
     mollusk_svm::{result::Check, Mollusk},
     solana_account::Account,


### PR DESCRIPTION
### Problem

There is a new v4 implementation of the memo program, so the v3 version can be deprecated.

### Solution

Deprecate the v3 implementation.