### PR TITLE
[codex] Fix clients-js oxfmt config loading

### DIFF
--- a/clients/js/oxfmt.config.mts
+++ b/clients/js/oxfmt.config.mts
@@ -1,0 +1,7 @@
+import solanaFmt from '@solana-config/oxc/oxfmt';
+import { defineConfig } from 'oxfmt';
+
+export default defineConfig({
+    ...solanaFmt,
+    ignorePatterns: ['**/dist/**', 'src/generated/**', 'test-ledger/**'],
+});

--- a/clients/js/oxfmt.config.ts
+++ b/clients/js/oxfmt.config.ts
@@ -1,7 +1,0 @@
-const oxfmt = require('oxfmt');
-const solanaFmt = require('@solana-config/oxc/oxfmt');
-
-module.exports = oxfmt.defineConfig({
-    ...solanaFmt,
-    ignorePatterns: ['**/dist/**', 'src/generated/**', 'test-ledger/**'],
-});

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -39,8 +39,8 @@
         "test": "vitest run",
         "lint": "oxlint",
         "lint:fix": "oxlint --fix",
-        "format": "oxfmt --check",
-        "format:fix": "oxfmt",
+        "format": "oxfmt -c oxfmt.config.mts --check",
+        "format:fix": "oxfmt -c oxfmt.config.mts",
         "prepublishOnly": "pnpm build"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

Fix `clients/js` Oxfmt config loading by switching the config file to an ESM TypeScript module and making the format scripts pass it explicitly with `-c`.

This keeps the shared `@solana-config/oxc/oxfmt` settings, including the generated/dist ignore patterns, without relying on the CommonJS `.ts` config shape that Oxfmt currently fails to link.

## Why

Running `pnpm format` in `clients/js` fails on `main` with:

```text
Failed to load configuration file.
.../clients/js/oxfmt.config.ts
Error: module is not linked
Ensure the file has a valid default export of a JSON-serializable configuration object.
```

This was originally noticed while fixing the Pinocchio JS test fixtures in #387, but was split out per review feedback.

## Validation

- `pnpm format` in `clients/js`
- `pnpm lint` in `clients/js`
- `pnpm build` in `clients/js`

Note: `pnpm test` in `clients/js` still fails on this branch because `main` expects `target/deploy/spl_memo.so`; that fixture is addressed separately in #387.
