### PR TITLE
Fix broken relative LICENSE link in program README

### DIFF
--- a/program/README.md
+++ b/program/README.md
@@ -54,4 +54,4 @@ SBF_OUT_DIR=../target/deploy cargo test
 
 ## License
 
-The code is licensed under the [Apache License Version 2.0](LICENSE)
+The code is licensed under the [Apache License Version 2.0](../LICENSE)


### PR DESCRIPTION
The Apache License link in `program/README.md` points to `LICENSE`, which resolves to `program/LICENSE` and 404s since the license file lives at the repository root. This repoints it to `../LICENSE`. No content change.
