### PR TITLE
Add clear signing display metadata to the IDL

### DIFF
--- a/idl.json
+++ b/idl.json
@@ -13,8 +13,7 @@
             "kind": "instructionArgumentNode",
             "name": "memo",
             "type": { "kind": "stringTypeNode", "encoding": "utf8" },
-            "docs": [],
-            "display": { "kind": "structFieldDisplayNode", "label": "Memo" }
+            "docs": []
           }
         ],
         "remainingAccounts": [

--- a/idl.json
+++ b/idl.json
@@ -13,7 +13,8 @@
             "kind": "instructionArgumentNode",
             "name": "memo",
             "type": { "kind": "stringTypeNode", "encoding": "utf8" },
-            "docs": []
+            "docs": [],
+            "display": { "kind": "structFieldDisplayNode", "label": "Memo" }
           }
         ],
         "remainingAccounts": [
@@ -21,13 +22,22 @@
             "kind": "instructionRemainingAccountsNode",
             "value": { "kind": "argumentValueNode", "name": "signers" },
             "isOptional": true,
-            "isSigner": true
+            "isSigner": true,
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Signers"
+            }
           }
         ],
         "name": "addMemo",
         "idlName": "addMemo",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Add memo",
+          "interpolatedIntent": "Add memo \"${data.memo}\""
+        }
       }
     ],
     "definedTypes": [],


### PR DESCRIPTION
This PR enriches the Codama IDL with display metadata for clear signing, per [sRFC 39](https://github.com/solana-foundation/SRFCs/discussions/4). The `addMemo` instruction gains an intent (`Add memo`), an interpolated intent quoting the memo text, and labels for the memo argument and the signer remaining accounts.

This allows wallets (including hardware wallets such as Ledger) to render human-readable messages for memo instructions via `@codama/dynamic-instructions`:

```
intent:       Add memo
interpolated: Add memo "gm, paying you back for lunch"
```

Clients were regenerated and are unaffected: renderers pass display metadata through untouched.